### PR TITLE
[NKI] Allow NKI transpiler to report descriptive errors for valid mug…

### DIFF
--- a/python/mirage/_cython/CCore.pxd
+++ b/python/mirage/_cython/CCore.pxd
@@ -276,8 +276,11 @@ cdef extern from "mirage/transpiler/transpile.h" namespace "mirage::transpiler":
 cdef extern from "mirage/nki_transpiler/transpile.h" namespace "mirage::nki_transpiler":
     ctypedef struct NKITranspilerConfig:
         int target_cc
+    ctypedef struct NKIErrorInfo:
+        vector[string] errors
     ctypedef struct NKITranspileResult:
         string code
+        NKIErrorInfo error_state
     cdef NKITranspileResult transpile(const CppKNGraph *graph,
                                       const NKITranspilerConfig config)
 

--- a/python/mirage/_cython/core.pyx
+++ b/python/mirage/_cython/core.pyx
@@ -981,9 +981,11 @@ def generate_nki_program(CyKNGraph input_graph, *, int target_cc) -> dict:
     
     # Call transpile
     cdef NKITranspileResult result = transpile(input_graph.p_kgraph, transpiler_config)
+    cdef list error_list = [error.decode("UTF-8") for error in result.error_state.errors]
 
     return {
         "code": result.code.decode("UTF-8"),
+        "errors": error_list,
     }
 
 def generate_triton_program(CyKNGraph input_graph, *, int target_cc) -> dict:


### PR DESCRIPTION
**Description of changes:**
Allow NKI transpiler to report descriptive error. Error are exposed as string buffer, to support future development purposes and easier debugging experience for cpp development.


**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #


